### PR TITLE
Bug fix: Add 'never' to IntervalUnit values.

### DIFF
--- a/src/Models/IntervalUnit.php
+++ b/src/Models/IntervalUnit.php
@@ -20,7 +20,9 @@ class IntervalUnit
 
     public const MONTH = 'month';
 
-    private const _ALL_VALUES = [self::DAY, self::MONTH];
+    public const NEVER = 'never';
+
+    private const _ALL_VALUES = [self::DAY, self::MONTH, self::NEVER];
 
     /**
      * Ensures that all the given values are present in this Enum.


### PR DESCRIPTION
It's possible for expirationIntervalUnit to contain "never" as a string, as per result below.

<img width="368" alt="image" src="https://github.com/maxio-com/ab-php-sdk/assets/50185207/484ba7e6-78f0-438a-b897-5b54621a1a7e">

This updates the recognised values to contain `never` to avoid the API from failing in the event that product price points do not have an expiry/lifetime to them. 

Would also recommend updating your documentation to this change:
https://developers.maxio.com/docs/api-docs/12857d2fd35b3-list-product-price-points